### PR TITLE
Faraday 1.0 Compatibility

### DIFF
--- a/faraday-raise-errors.gemspec
+++ b/faraday-raise-errors.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "faraday"
 
-  spec.add_development_dependency "bundler", "~> 1.7"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake"
 end

--- a/faraday-raise-errors.gemspec
+++ b/faraday-raise-errors.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "faraday"
+  spec.add_dependency "faraday", ">= 0.9.0"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"

--- a/lib/faraday/raise_errors.rb
+++ b/lib/faraday/raise_errors.rb
@@ -8,10 +8,10 @@ module Faraday
     def on_complete(env)
       case env[:status]
       when 404
-        raise Faraday::Error::ResourceNotFound, response_values(env)
+        raise Faraday::ResourceNotFound, response_values(env)
       when 407
         # mimic the behavior that we get with proxy requests with HTTPS
-        raise Faraday::Error::ConnectionFailed, %{407 "Proxy Authentication Required "}
+        raise Faraday::ConnectionFailed, %{407 "Proxy Authentication Required "}
       when 400..599
         error = Faraday::HTTP::ERRORS.fetch(env[:status], :UnrecognizedResponse)
         exception = Faraday::HTTP.const_get error

--- a/lib/faraday/raise_errors/version.rb
+++ b/lib/faraday/raise_errors/version.rb
@@ -2,6 +2,6 @@ require "faraday"
 
 module Faraday
   class RaiseErrors < ::Faraday::Response::Middleware
-    VERSION = "0.3.0"
+    VERSION = "0.4.0"
   end
 end


### PR DESCRIPTION
### Summary
Faraday 1.0 is out! 🎉 ... However, it looks like they've consolidated their error namespaces, removing the `Faraday::Error` namespace altogether and having errors only available on the root `Faraday` module. This PR updates this middleware to be in-line with this change and unlocks using it with Faraday 1.0.